### PR TITLE
Add stable hostname option

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@jamsocket/javascript",
   "scripts": {
     "build": "tsc",
-    "clean": "rm -r dist && rm tsconfig.tsbuildinfo",
+    "clean": "rm -rf dist && rm -f tsconfig.tsbuildinfo",
     "dev": "npm run build -- --watch",
     "prepare": "npm run clean && npm run build",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,22 +10,22 @@ export type JamsocketInitOptions = {
 }
 
 export type JamsocketSpawnOptions = {
-  tag?: string,
-  lock?: string,
-  env?: Record<string, string>,
-  gracePeriodSeconds?: number,
-  requireBearerToken?: boolean,
-  stableHostname?: boolean,
+  tag?: string
+  lock?: string
+  env?: Record<string, string>
+  gracePeriodSeconds?: number
+  requireBearerToken?: boolean
+  stableHostname?: boolean
 }
 
 type JamsocketApiSpawnBody = {
-  tag?: string,
-  lock?: string,
-  env?: Record<string, string>,
-  grace_period_seconds?: number,
-  require_bearer_token?: boolean,
-  port?: number,
-  stable_hostname?: boolean,
+  tag?: string
+  lock?: string
+  env?: Record<string, string>
+  grace_period_seconds?: number
+  require_bearer_token?: boolean
+  port?: number
+  stable_hostname?: boolean
 }
 
 const JAMSOCKET_API = 'https://api.jamsocket.com'
@@ -42,7 +42,8 @@ export function init(opts: JamsocketInitOptions) {
     if (spawnOpts.gracePeriodSeconds) reqBody.grace_period_seconds = spawnOpts.gracePeriodSeconds
     if (spawnOpts.requireBearerToken) reqBody.require_bearer_token = spawnOpts.requireBearerToken
 
-    if (spawnOpts.stableHostname && !spawnOpts.lock) throw new Error('stableHostname requires lock to be set')
+    if (spawnOpts.stableHostname && !spawnOpts.lock)
+      throw new Error('stableHostname requires lock to be set')
 
     if (spawnOpts.stableHostname) reqBody.stable_hostname = spawnOpts.stableHostname
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ export type JamsocketSpawnOptions = {
   env?: Record<string, string>,
   gracePeriodSeconds?: number,
   requireBearerToken?: boolean,
+  stableHostname?: boolean,
 }
 
 type JamsocketApiSpawnBody = {
@@ -24,6 +25,7 @@ type JamsocketApiSpawnBody = {
   grace_period_seconds?: number,
   require_bearer_token?: boolean,
   port?: number,
+  stable_hostname?: boolean,
 }
 
 const JAMSOCKET_API = 'https://api.jamsocket.com'
@@ -39,6 +41,10 @@ export function init(opts: JamsocketInitOptions) {
     if (spawnOpts.env) reqBody.env = spawnOpts.env
     if (spawnOpts.gracePeriodSeconds) reqBody.grace_period_seconds = spawnOpts.gracePeriodSeconds
     if (spawnOpts.requireBearerToken) reqBody.require_bearer_token = spawnOpts.requireBearerToken
+
+    if (spawnOpts.stableHostname && !spawnOpts.lock) throw new Error('stableHostname requires lock to be set')
+
+    if (spawnOpts.stableHostname) reqBody.stable_hostname = spawnOpts.stableHostname
 
     const response = await fetch(`${apiUrl}/user/${account}/service/${service}/spawn`, {
       method: 'POST',


### PR DESCRIPTION
This allows setting `stableHostname` on a spawn request. This feature will be implemented in Jamsocket, and adding it to the API in advance is necessary to add tests for it.