### PR TITLE
make socket.io work with paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jamsocket/javascript",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jamsocket/javascript",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "isomorphic-fetch": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "prepare": "npm run clean && npm run build",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "JavaScript/TypeScript, and React libraries for interacting with session backends and the Jamsocket platform.",
   "exports": {
     "./server": "./dist/server.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@jamsocket/javascript",
   "scripts": {
     "build": "tsc",
-    "clean": "rm -r dist && rm tsconfig.tsbuildinfo",
+    "clean": "rm -rf dist && rm -f tsconfig.tsbuildinfo",
     "dev": "npm run build -- --watch",
     "prepare": "npm run clean && npm run build",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""

--- a/src/client.ts
+++ b/src/client.ts
@@ -135,7 +135,13 @@ export class SessionBackend {
   }
 
   private openSocket() {
-    this.socket = io(this.url, this.socketOpts)
+    const url = new URL(this.url)
+    const path =
+      url.pathname[url.pathname.length - 1] === '/'
+        ? url.pathname.substring(0, url.pathname.length - 1)
+        : url.pathname
+    const socketOpts = path ? { ...this.socketOpts, path: `${path}/socket.io/` } : this.socketOpts
+    this.socket = io(url.origin, socketOpts)
     this.socket.on('connect', () => {
       this._isReady = true
       this._onReady.forEach((cb) => cb())


### PR DESCRIPTION
If the backend's URL includes a path, we need to pass that path to socket.io separately in order for socket.io to connect correctly.