### PR TITLE
make opts easier to use in dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ JavaScript/TypeScript, and React libraries for interacting with session backends
 npm install @jamsocket/javascript
 ```
 
+### Spawning backends
+
 ```js
 import { init } from '@jamsocket/javascript/server'
 
@@ -30,6 +32,16 @@ const spawnResult = await spawnBackend({
   requireBearerToken: true,
 })
 ```
+
+When developing locally with the [Jamsocket Dev CLI](https://docs.jamsocket.com/platform/dev-cli), you may omit the `account`, `token`, and `service` fields from the `init()` options, and instead pass `dev: true`.
+
+```ts
+const spawnBackend = init({
+  dev: true
+})
+```
+
+### React Hooks
 
 ```jsx
 import { SessionBackendProvider } from '@jamsocket/javascript/react'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jamsocket/javascript",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jamsocket/javascript",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "isomorphic-fetch": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "prepare": "npm run clean && npm run build",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "JavaScript/TypeScript, and React libraries for interacting with session backends and the Jamsocket platform.",
   "exports": {
     "./server": "./dist/server.js",


### PR DESCRIPTION
This makes it so you can just pass `{dev: true}` to the `init()` function when developing with the Jamsocket Dev CLI instead of passing dummy values for `account`, `token`, and `service`.

This also updates the README and bumps the version to `v0.1.3` (just a patch version because this change is backwards compatible).